### PR TITLE
fix for 'Standings' object has no attribute 'divisions'

### DIFF
--- a/renderers/main.py
+++ b/renderers/main.py
@@ -64,7 +64,7 @@ class MainRenderer:
 
     # Render the standings screen
     def __render_standings(self) -> NoReturn:
-        if self.data.standings.preferred_divisions:
+        if self.data.standings.standings:
             self.__draw_standings(True)
         else:
             # Out of season off days don't always return standings so fall back on the offday renderer

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -64,7 +64,7 @@ class MainRenderer:
 
     # Render the standings screen
     def __render_standings(self) -> NoReturn:
-        if self.data.standings.divisions:
+        if self.data.standings.preferred_divisions:
             self.__draw_standings(True)
         else:
             # Out of season off days don't always return standings so fall back on the offday renderer


### PR DESCRIPTION
After merging today's changes I started up using a configuration to display standings, and it crashed.  I'll attach the configuration.  This pull is a suggested fix. 
```
DEBUG (00:05:04): Fetching https://www.mlbtraderumors.com/baltimore-orioles/feed/atom
DEBUG (00:05:06): Fetched feed 'b'Baltimore Orioles  MLB Trade Rumors'' with 15 entries.
DEBUG (00:05:07): Main has selected the standings to refresh
Exception in thread render_thread:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/home/pi/mlb-scoreboard/main.py", line 132, in __render_main
    MainRenderer(matrix, data).render()
  File "/home/pi/mlb-scoreboard/renderers/main.py", line 34, in render
    self.__render_standings()
  File "/home/pi/mlb-scoreboard/renderers/main.py", line 67, in __render_standings
    if self.data.standings.divisions:
AttributeError: 'Standings' object has no attribute 'divisions'
```
[config-standings.json.txt](https://github.com/WardBrian/mlb-led-scoreboard/files/7290781/config-standings.json.txt)

