### PR TITLE
handle screen clear on ^C

### DIFF
--- a/main.py
+++ b/main.py
@@ -145,5 +145,8 @@ if __name__ == "__main__":
     except Exception:
         debug.exception("Untrapped error in main!")
         raise
+    except KeyboardInterrupt:
+        debug.exception("Control-C pressed!")
+        sys.exit(1)
     finally:
         matrix.Clear()


### PR DESCRIPTION
We could have just made line 145 read "except:" - this does the trick but produces an unnecessarily long stack trace. 